### PR TITLE
added support for --cc and --bcc flags in email sending

### DIFF
--- a/cli/cliargs.go
+++ b/cli/cliargs.go
@@ -18,6 +18,9 @@ type CLIArgs struct {
 	SheetURL     string   // Optional Google Sheet URL for CSV import
 	Filter       string   // Logical filter expression for recipients
 	Attachments  []string // File paths to attach to every email
+	Cc           string   // Comma-separated emails or file path for CC
+	Bcc          string   // Comma-separated emails or file path for BCC
+
 }
 
 // ParseFlags reads command-line flags using spf13/pflag and returns a filled CLIArgs struct.
@@ -28,6 +31,8 @@ func ParseFlags() CLIArgs {
 	pflag.StringVar(&args.CSVPath, "csv", "", "Path to recipient CSV file")
 	pflag.StringVar(&args.SheetURL, "sheet-url", "", "Public Google Sheet URL (replaces --csv)")
 	pflag.StringVarP(&args.TemplatePath, "template", "t", "", "Path to email HTML template")
+	pflag.StringVar(&args.Cc, "cc", "", "Comma-separated emails or file path for CC")
+	pflag.StringVar(&args.Bcc, "bcc", "", "Comma-separated emails or file path for BCC")
 	pflag.StringVarP(&args.Subject, "subject", "s", "Test Email from Mailgrid", "Email subject (templated with {{ .field }})")
 	pflag.BoolVar(&args.DryRun, "dry-run", false, "Render emails to console without sending")
 	pflag.BoolVarP(&args.ShowPreview, "preview", "p", false, "Start a local preview server to view rendered email")

--- a/cli/tasks.go
+++ b/cli/tasks.go
@@ -36,6 +36,13 @@ func PrepareEmailTasks(recipients []parser.Recipient, templatePath, subjectTpl s
 				continue
 			}
 		}
+		// Log CC and BCC addresses
+		if len(ccList) > 0 {
+			log.Printf("📧 Adding CC: %v to email for %s", ccList, r.Email)
+		}
+		if len(bccList) > 0 {
+			log.Printf("📧 Adding BCC: %v to email for %s", bccList, r.Email)
+		}
 
 		// Render personalized subject line
 		var sb bytes.Buffer
@@ -71,6 +78,13 @@ func HasMissingFields(r parser.Recipient) bool {
 func printDryRun(tasks []email.Task) {
 	for i, t := range tasks {
 		fmt.Printf(" Email #%d → %s\nSubject: %s\n", i+1, t.Recipient.Email, t.Subject)
+
+		if len(t.CC) > 0 {
+			fmt.Printf("CC: %v\n", t.CC)
+		}
+		if len(t.BCC) > 0 {
+			fmt.Printf("BCC: %v\n", t.BCC)
+		}
 		if len(t.Attachments) > 0 {
 			fmt.Printf("Attachments: %v\n", t.Attachments)
 		}

--- a/cli/tasks.go
+++ b/cli/tasks.go
@@ -13,7 +13,7 @@ import (
 
 // PrepareEmailTasks renders the subject and body templates for each recipient
 // and returns a list of email.Task objects ready for sending.
-func PrepareEmailTasks(recipients []parser.Recipient, templatePath, subjectTpl string, attachments []string) ([]email.Task, error) {
+func PrepareEmailTasks(recipients []parser.Recipient, templatePath, subjectTpl string, attachments []string, ccList []string, bccList []string) ([]email.Task, error) {
 	tmpl, err := template.New("subject").Parse(subjectTpl)
 	if err != nil {
 		return nil, fmt.Errorf("invalid subject template: %w", err)
@@ -49,6 +49,8 @@ func PrepareEmailTasks(recipients []parser.Recipient, templatePath, subjectTpl s
 			Subject:     sb.String(),
 			Body:        body,
 			Attachments: attachments,
+			CC:          ccList,
+			BCC:         bccList,
 			Retries:     0,
 		})
 	}

--- a/cli/tasks.go
+++ b/cli/tasks.go
@@ -36,13 +36,6 @@ func PrepareEmailTasks(recipients []parser.Recipient, templatePath, subjectTpl s
 				continue
 			}
 		}
-		// Log CC and BCC addresses
-		if len(ccList) > 0 {
-			log.Printf("📧 Adding CC: %v to email for %s", ccList, r.Email)
-		}
-		if len(bccList) > 0 {
-			log.Printf("📧 Adding BCC: %v to email for %s", bccList, r.Email)
-		}
 
 		// Render personalized subject line
 		var sb bytes.Buffer
@@ -78,13 +71,6 @@ func HasMissingFields(r parser.Recipient) bool {
 func printDryRun(tasks []email.Task) {
 	for i, t := range tasks {
 		fmt.Printf(" Email #%d → %s\nSubject: %s\n", i+1, t.Recipient.Email, t.Subject)
-
-		if len(t.CC) > 0 {
-			fmt.Printf("CC: %v\n", t.CC)
-		}
-		if len(t.BCC) > 0 {
-			fmt.Printf("BCC: %v\n", t.BCC)
-		}
 		if len(t.Attachments) > 0 {
 			fmt.Printf("Attachments: %v\n", t.Attachments)
 		}

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -27,6 +27,8 @@ mailgrid send \
 | `--sheet-url`    | —         | `""`                       | Google Sheet CSV URL as an alternative to local `--csv` file.                              |
 | `--template`     | `-t`      | `example/welcome.html`     | Path to the HTML email template with Go-style placeholders.                                |
 | `--subject`      | `-s`      | `Test Email from Mailgrid` | The subject line of the email. Can be overridden per run.                                  |
+| `--cc`           | —         | `""`                       | Comma-separated list or file (`@file.txt`) of CC email addresses (visible recipients).      |
+| `--bcc`          | —         | `""`                       | Comma-separated list or file (`@file.txt`) of BCC addresses (hidden from recipients).       |
 | `--dry-run`      | —         | `false`                    | If set, renders the emails to console without sending them via SMTP.                       |
 | `--preview`      | `-p`      | `false`                    | Start a local server to preview the rendered email in browser.                             |
 | `--preview-port` | `--port`  | `8080`                     | Port for the preview server when using `--preview` flag.                                   |
@@ -121,6 +123,40 @@ Example:
 ```bash
 mailgrid send \
   --subject "Monthly update for {{ .company }}" \
+  --csv contacts.csv \
+  --template newsletter.html
+```
+---
+#### `--cc`
+
+Define one or more CC (carbon copy) recipients for the outgoing email.
+
+- These addresses will appear in the Cc: header and be visible to all recipients.
+- Accepts a comma-separated string or a file reference using the @ symbol.
+- Useful when you want to transparently include teammates, managers, or collaborators.
+
+Example:
+
+```bash
+mailgrid send \
+  --cc "team@example.com,manager@example.com" \
+  --csv contacts.csv \
+  --template newsletter.html
+```
+---
+#### `--bcc`
+
+Define one or more BCC (blind carbon copy) recipients for each email.
+
+- These addresses receive the email silently—they don’t appear in the To: or Cc: headers.
+- Accepts a comma-separated string or a file reference with @.
+- Great for logging, supervisors, or invisible monitoring.
+
+Example:
+
+```bash
+mailgrid send \
+  --bcc "admin@example.com" \
   --csv contacts.csv \
   --template newsletter.html
 ```

--- a/email/dispatcher.go
+++ b/email/dispatcher.go
@@ -1,9 +1,9 @@
 package email
 
 import (
-	"log"
 	"github.com/bravo1goingdark/mailgrid/config"
 	"github.com/bravo1goingdark/mailgrid/parser"
+	"log"
 	"sync"
 )
 
@@ -14,6 +14,8 @@ type Task struct {
 	Body        string
 	Retries     int
 	Attachments []string
+	CC          []string
+	BCC         []string
 }
 
 type worker struct {

--- a/tests/cli/tasks_test.go
+++ b/tests/cli/tasks_test.go
@@ -51,7 +51,7 @@ func TestPrepareEmailTasks(t *testing.T) {
 		return
 	}
 
-	tasks, err := cli.PrepareEmailTasks(recipients, tmp.Name(), "Hello {{.name }}", []string{a.Name()})
+	tasks, err := cli.PrepareEmailTasks(recipients, tmp.Name(), "Hello {{.name }}", []string{a.Name()}, []string{}, []string{})
 	if err != nil {
 		t.Fatalf("prepareEmailTasks error: %v", err)
 	}
@@ -76,7 +76,7 @@ func TestPrepareEmailTasks_AttachOnly(t *testing.T) {
 	a.WriteString("file")
 	a.Close()
 
-	tasks, err := cli.PrepareEmailTasks(recipients, "", "Hi", []string{a.Name()})
+	tasks, err := cli.PrepareEmailTasks(recipients, "", "Hi", []string{a.Name()}, []string{}, []string{})
 	if err != nil {
 		t.Fatalf("prepareEmailTasks error: %v", err)
 	}

--- a/tests/cli/tasks_test.go
+++ b/tests/cli/tasks_test.go
@@ -87,3 +87,34 @@ func TestPrepareEmailTasks_AttachOnly(t *testing.T) {
 		t.Errorf("expected empty body")
 	}
 }
+
+func TestPrepareEmailTasks_CC_BCC(t *testing.T) {
+	recipients := []parser.Recipient{
+		{Email: "jacob@example.com", Data: map[string]string{"name": "Jacob"}},
+	}
+
+	tasks, err := cli.PrepareEmailTasks(
+		recipients,
+		"",
+		"Test Subject",
+		[]string{},
+		[]string{"cc1@example.com"},
+		[]string{"bcc1@example.com"},
+	)
+	if err != nil {
+		t.Fatalf("prepareEmailTasks error: %v", err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("expected 1 task, got %d", len(tasks))
+	}
+
+	task := tasks[0]
+
+	if len(task.CC) != 1 || task.CC[0] != "cc1@example.com" {
+		t.Errorf("expected cc to be [cc1@example.com], got %v", task.CC)
+	}
+
+	if len(task.BCC) != 1 || task.BCC[0] != "bcc1@example.com" {
+		t.Errorf("expected bcc to be [bcc1@example.com], got %v", task.BCC)
+	}
+}


### PR DESCRIPTION
## Feature: Add Support for CC and BCC in Mailgrid CLI

### Summary

This PR adds support for sending emails with `CC` (Carbon Copy) and `BCC` (Blind Carbon Copy) recipients through the Mailgrid CLI.

### Changes

- Introduced `--cc` and `--bcc` CLI flags.
- Both flags support:
 - Inline input: comma-separated list of emails.
- File input: one email per line.
- Updated `PrepareEmailTasks` to include `CC` and `BCC` handling.
- Updated tests to validate CC and BCC behavior.

### Example Usage

```bash
./mailgrid --csv example/fake_batch_1.csv \
           --env example/config.json \
           -t example/welcome.html \
           -s "Welcome {{.name}}" \
           --cc "shivamjha2436@gmail.com,rishujha87362@gmail.com" \
           --bcc bcc_list.txt